### PR TITLE
Fix initialization and incompatible settings bugs

### DIFF
--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1,0 +1,47 @@
+test_that("ocp can be initialised with multiple dimensions", {
+  empty_ocpd <- initOCPD(dims=5)
+  expect_equal(length(empty_ocpd$update_params0), 5)
+})
+
+test_that("ocp can be initialised with a vector of parameters", {
+  empty_ocpd <- initOCPD(dims=5, init_params = replicate(5, list(list(m=0, k=0.01, a=0.01, b=0.0001))))
+  expect_equal(length(empty_ocpd$update_params0), 5)
+})
+
+test_that("ocp can be initialised with a single set of parameters", {
+  empty_ocpd <- initOCPD(dims=5, init_params = list(list(m=0, k=0.01, a=0.01, b=0.0001)))
+  expect_equal(length(empty_ocpd$update_params0), 5)
+})
+
+test_that("ocp can't be initialised with a vector of distributions without parameters", {
+  expect_error(
+    empty_ocpd <- initOCPD(dims=5, init_prob = replicate(5, poisson_init))
+  )
+})
+
+test_that("ocp can't be initialised with a scalar distributions without parameters", {
+  expect_error(
+    empty_ocpd <- initOCPD(dims=5, init_prob = poisson_init)
+  )
+})
+
+test_that("ocp can be initialised with a vector of distributions", {
+  empty_ocpd <- initOCPD(dims=5, init_prob = replicate(5, poisson_init), init_params = list(list(a=1, b=1)))
+  expect_equal(length(empty_ocpd$update_params0), 5)
+})
+
+test_that("ocp can be initialised with a scalar distributions", {
+  empty_ocpd <- initOCPD(dims=5, init_prob = poisson_init, list(list(a=1, b=1)))
+  expect_equal(length(empty_ocpd$update_params0), 5)
+})
+
+test_that("ocp can be initialised and then updated", {
+  expect_error({
+    empty_ocpd <- initOCPD(dims=5)
+    onlineCPD(
+      matrix(rnorm(50), ncol=5),
+      multivariate = T,
+      oCPD = empty_ocpd
+    )
+  }, NA)
+})


### PR DESCRIPTION
Closes #1, #2. Tests are included.

I fixed #1 by replicating each parameter set by the number of dimensions. #2 is fixed by using `as.list(environment())` instead of `match.call()` as this better captures the parameter set. I also don't throw a failure if the OCP object has no settings, which is what happens after using `init`.

I also renamed `initProb` to `init_prob` because I didn't like the inconsistency, but there are a few other instances of that so it probably wasn't needed.